### PR TITLE
  Remove SITEURL prefix from MENUITEMS links

### DIFF
--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -6,7 +6,7 @@
                     <h1 class="brand-main"><a href="/">{{ SITENAME }}</a></h1>
                     <p class="tagline">{{ TAGLINE }}</p>
                 {% for title, link in MENUITEMS %}
-                    <p class="links"><a href="{{ SITEURL }}/{{ link }}">{{ title }}</a></p>
+                    <p class="links"><a href="{{ link }}">{{ title }}</a></p>
                 {% endfor %}
                     <p class="social">
                 {% for title, link in SOCIAL %}


### PR DESCRIPTION
MENUITEMS links could be external links for authors. This thus should
not be automatically prefixed by the SITEURL.