### PR TITLE
Add guages.io and piwik analytics to README and template

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,16 @@ Theme is responsive.
 * `PROFILE_IMAGE_URL` - Set the image/logo for the top circle cutout on sidebar.
 * `TAGLINE` - Used for the page titles and some meta tags.
 * `DISQUS_SITENAME` - Set this to enable disqus comments in articles.
+
+### ANALYTICS settings
+
 * `GOOGLE_ANALYTICS` - Set the Google Analytics code (eg. "UA-000000-00")
+* `GUAGES` = Set Guages.io analytics data-side-id
+* `PIWIK_SITE_ID` = Set PIWIK id
+* `PIWIK_URL` = Set PIWIK hosting URL
+
+### SOCIAL settings
+
 * `SOCIAL` - Set some social links in the sidebar. The format should be like this:
 
     ```python

--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -10,3 +10,38 @@
             } catch(err) {}
     </script>
 {% endif %}
+{% if GAUGES %}
+    <script type="text/javascript">
+    var _gauges = _gauges || [];
+    (function() {
+        var t   = document.createElement('script');
+        t.type  = 'text/javascript';
+        t.async = true;
+        t.id    = 'gauges-tracker';
+        t.setAttribute('data-site-id', '{{GAUGES}}');
+        t.src = '//secure.gaug.es/track.js';
+        var s = document.getElementsByTagName('script')[0];
+        s.parentNode.insertBefore(t, s);
+    })();
+    </script>
+{% endif %}
+{% if PIWIK_URL and PIWIK_SITE_ID %}
+    <script type="text/javascript">
+    {% if PIWIK_SSL_URL %}
+        var pkBaseURL = "{{ PIWIK_SSL_URL }}";
+    {% else %}
+        var pkBaseURL = "{{ PIWIK_URL }}";
+    {% endif %}
+    var _paq = _paq || [];
+    _paq.push(["trackPageView"]);
+    _paq.push(["enableLinkTracking"]);
+    (function() {
+        var u=(("https:" == document.location.protocol) ? "https" : "http")+"://"+pkBaseURL+"/";
+        _paq.push(["setTrackerUrl", u+"piwik.php"]);
+        _paq.push(["setSiteId", "{{ PIWIK_SITE_ID }}"]);
+        var d=document, g=d.createElement("script"), s=d.getElementsByTagName("script")[0]; g.type="text/javascript";
+        g.defer=true; g.async=true; g.src=u+"piwik.js"; s.parentNode.insertBefore(g,s);
+    })();
+    </script>
+    <noscript><p><img src="//{{PIWIK_SITE_URL}}/piwik.php?idsite={{PIWIK_SITE_ID}}" style="border:0;" alt="" /></p></noscript>
+{% endif %}


### PR DESCRIPTION
The code was lifted from a more recent version of Pelican's own template/analytics.html.

I can only test PIWIK support.  Guages was just paste and pray.